### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,9 @@
 
         function getResults() {
 
-            standard_rate = 0.10;
-            premium_rate = 0.20;
-            extreme_rate = 0.30;
+            standard_rate = 0.20;
+            premium_rate = 0.30;
+            extreme_rate = 0.40;
             swstandard_rate = 0.25;
             swstandardredundant_rate = 0.40;
             standard_tputpertib = 16;


### PR DESCRIPTION
Edited pricing details to reflect new pricing changes to CVS as of 1st June 2022
New Pricing
            standard_rate = 0.20;
            premium_rate = 0.30;
            extreme_rate = 0.40;

Old pricing

            standard_rate = 0.10;
            premium_rate = 0.20;
            extreme_rate = 0.30;